### PR TITLE
typo

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ node() {
       sh "npm install && npm update && npm test"
   }
   stage('build odinapi') {
-    odinapiImage = docker.build("odinsmr/odin-api")
+    odinapiImage = docker.build("odinsmr/odin_api")
   }
   stage('build proxy') {
     proxyImage = docker.build("odinsmr/proxy", "services/proxy")


### PR DESCRIPTION
Wrong name on the image... had a thought to change it to "odin-api" but all docker-compose files we use uses "odin_api", so I chose the simples path.