### PR TITLE
years as integers in level1stat plot

### DIFF
--- a/src/odinapi/static/js/level1statistics.js
+++ b/src/odinapi/static/js/level1statistics.js
@@ -142,6 +142,7 @@ function drawStatistics(year) {
             },
             xaxis: {
                 ticks: xticks,
+                tickDecimals: 0,
             },
             grid: {
                 hoverable: true,


### PR DESCRIPTION
years as integers on x-axis in level1stat plot.
have verified that this solves the issue by inspecting
http://localhost:5000/level1statistics


resolves #odin2