### PR TITLE
Removing some documentation

### DIFF
--- a/src/odinapi/utils/swagger.py
+++ b/src/odinapi/utils/swagger.py
@@ -351,6 +351,8 @@ class SwaggerSpecView(MethodView):
     def collect_path_specifications(self, version):
         paths = {}
         for rule in current_app.url_map.iter_rules():
+            if "/development/" in rule.rule or "/freqmode_raw/" in rule.rule:
+                continue
             endpoint = current_app.view_functions[rule.endpoint]
             if is_base_view(endpoint):
                 path = self.rule_to_swagger_path(rule, version)

--- a/src/systemtest/test_browser.py
+++ b/src/systemtest/test_browser.py
@@ -161,3 +161,14 @@ def delete_level2data(host, offset=0):
         PROJECT_NAME)
     url = WRITE_URL.format(host=host, version=VERSION, d=datastring)
     requests.delete(url)
+
+
+class TestSwaggerBrowser:
+    @pytest.fixture
+    def apidocs(self, chrome, odinapi_service):
+        chrome.get("{}/apidocs/index.html".format(odinapi_service))
+        return chrome
+
+    def test_has_expected_title(self, apidocs):
+        title = apidocs.find_element_by_class_name('info_title')
+        assert title.text == "Odin API"

--- a/src/systemtest/test_browser.py
+++ b/src/systemtest/test_browser.py
@@ -161,14 +161,3 @@ def delete_level2data(host, offset=0):
         PROJECT_NAME)
     url = WRITE_URL.format(host=host, version=VERSION, d=datastring)
     requests.delete(url)
-
-
-class TestSwaggerBrowser:
-    @pytest.fixture
-    def apidocs(self, chrome, odinapi_service):
-        chrome.get("{}/apidocs/index.html".format(odinapi_service))
-        return chrome
-
-    def test_has_expected_title(self, apidocs):
-        title = apidocs.find_element_by_class_name('info_title')
-        assert title.text == "Odin API"


### PR DESCRIPTION
This removes uri containing `/freqmode_raw/` or `/development/` from the api spec.
It's a bit of a hack but the whole swagger thing is a bit of a hack.

I tried to write tests for it, but it seems problematic because selenium only answers about what is visible, and the page loads a bit asynchronously and stuff also end up outside the window so it wasn't as straight forward as one could have hoped.

Resolves #20 