### PR TITLE
using era5 data after 2019-08-31

### DIFF
--- a/src/odinapi/views/NC4era.py
+++ b/src/odinapi/views/NC4era.py
@@ -1,7 +1,8 @@
 '''
 Created on Mar 12, 2009
 New version Oct 2014 - dicovered that geometric height was in the files
-new version April 2015 - to use ERA interim files retreived using the ECMWF API
+new version April 2015 - to use ERA interim or ERA5 files retreived
+using the ECMWF API
 @author: donal
 '''
 from itertools import product
@@ -9,7 +10,7 @@ from netCDF4 import Dataset
 import numpy as np
 
 
-class NCeraint:
+class NCera:
     def __init__(self, filename, ind):
         '''
         This routine will allow us to access

--- a/src/odinapi/views/newdonalettyERANC.py
+++ b/src/odinapi/views/newdonalettyERANC.py
@@ -10,7 +10,7 @@ from scipy.interpolate import BSpline, splrep
 from simpleflock import SimpleFlock
 
 import odinapi.views.msis90 as M90
-from odinapi.views.NC4eraint import NCeraint
+from odinapi.views.NC4era import NCera
 from odinapi.views.date_tools import mjd2datetime, datetime2mjd
 
 
@@ -144,16 +144,12 @@ class Donaletty:
                 # we need to read data from one day later : time 00
                 date = self.datetime.date() + DT.timedelta(days=1)
                 hourstr = '00'
-                # file_time_index = 0
             else:
                 date = self.datetime.date()
-                # file_time_index = ind
-
             ecmwffilename = self.get_filepath(date, hourstr)
-            # print ecmwffilename
             # TODO: Opening more than one netcdf file at the same time
             #       can result in segfault.
-            self.ecm.append(NCeraint(ecmwffilename, 0))
+            self.ecm.append(NCera(ecmwffilename, 0))
 
         self.minlat = self.ecm[0]['lats'][0]
         self.latstep = np.mean(np.diff(self.ecm[0]['lats']))

--- a/src/odinapi/views/newdonalettyERANC.py
+++ b/src/odinapi/views/newdonalettyERANC.py
@@ -149,14 +149,7 @@ class Donaletty:
                 date = self.datetime.date()
                 # file_time_index = ind
 
-            ecmwffilename = os.path.join(
-                self.ecmwfpath,
-                date.strftime('%Y/%m'),
-                'ei_pl_{}-{}.nc'.format(
-                    date.strftime('%Y-%m-%d'),
-                    hourstr
-                )
-            )
+            ecmwffilename = self.get_filepath(date, hourstr)
             # print ecmwffilename
             # TODO: Opening more than one netcdf file at the same time
             #       can result in segfault.
@@ -166,6 +159,20 @@ class Donaletty:
         self.latstep = np.mean(np.diff(self.ecm[0]['lats']))
         self.minlon = self.ecm[0]['lons'][0]
         self.lonstep = np.mean(np.diff(self.ecm[0]['lons']))
+
+    def get_filepath(self, date, hour):
+        # ERA-Interim (ei) data is used before 2019-09-01,
+        # and ERA5 (ea) data afterwards
+        prefix = "ei" if date < datetime(2019, 9, 1).date() else "ea"
+        return os.path.join(
+            self.ecmwfpath,
+            date.strftime('%Y/%m'),
+            '{prefix}_pl_{date}-{hour}.nc'.format(
+                prefix=prefix,
+                date=date.strftime('%Y-%m-%d'),
+                hour=hour
+            )
+        )
 
     def makeprofile(self, midlat, midlon, scan_datetime, scanid):
 

--- a/src/test/views/test_donaletty.py
+++ b/src/test/views/test_donaletty.py
@@ -1,10 +1,11 @@
 import os
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, date
 import pytest
 import numpy as np
 
-from odinapi.views.newdonalettyERANC import run_donaletty
+from odinapi.views.newdonalettyERANC import (
+    run_donaletty, Donaletty)
 from odinapi.views.msis90 import Msis90
 
 
@@ -46,6 +47,40 @@ def ptz_data(inputdatapath, outputdatapath):
         )
     )
     return data
+
+
+@pytest.mark.parametrize('basedir,current_date,hour,expect', (
+    (
+        "/test1", date(2019, 8, 31), "12",
+        "/test1/2019/08/ei_pl_2019-08-31-12.nc"),
+    (
+        "/test2", date(2019, 8, 31), "18",
+        "/test2/2019/08/ei_pl_2019-08-31-18.nc"),
+    (
+        "/test3", date(2019, 9, 1),
+        "00", "/test3/2019/09/ea_pl_2019-09-01-00.nc"),
+    (
+        "/test4", date(2019, 9, 1), "06",
+        "/test4/2019/09/ea_pl_2019-09-01-06.nc"),
+))
+def test_get_filepath(basedir, current_date, hour, expect):
+    donaletty = Donaletty(current_date, "dummy", basedir)
+    filename = donaletty.get_filepath(current_date, hour)
+    assert filename == expect
+
+
+def test_loadecmwfdata_reads_expected_files(inputdatapath):
+    basedir = os.path.join(inputdatapath, 'ERA-Interim')
+    current_datetime = datetime(2015, 1, 12, 1)
+    donaletty = Donaletty(current_datetime, "dummy", basedir)
+    donaletty.loadecmwfdata()
+    assert [
+        donaletty.ecm[0]["fid"].filepath(),
+        donaletty.ecm[1]["fid"].filepath()
+    ] == [
+        os.path.join(basedir, "2015/01/ei_pl_2015-01-12-00.nc"),
+        os.path.join(basedir, "2015/01/ei_pl_2015-01-12-06.nc")
+    ]
 
 
 @pytest.mark.parametrize('parameter,index,expect', (


### PR DESCRIPTION
adapt to use are5 data after 2018-08-31. It was found that only the functionality that generates PTZ data needed to be updated.
The endpoint that reports the latest available ecmwf file does not care about the file prefix
and does not need to be updated., i.e this url
http://odin.rss.chalmers.se/rest_api/v5/config_data/latest_ecmf_file/ 
says the latest file is from 2020-01-31 which is expected as there is 3 months of delay in data production of the reanalysis data

Resloves #27 
