### PR TITLE
Switch to pycryptodome

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -15,7 +15,7 @@ netcdf4
 numpy
 psycopg2-binary
 pycodestyle
-pycrypto
+pycryptodome
 pyephem
 pyflakes
 pygresql

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ netcdf4==1.5.3            # via -r requirements.in
 numpy==1.18.1             # via -r requirements.in, cftime, h5py, matplotlib, netcdf4, scipy
 psycopg2-binary==2.8.4    # via -r requirements.in
 pycodestyle==2.5.0        # via -r requirements.in
-pycrypto==2.6.1           # via -r requirements.in
+pycryptodome==3.9.7       # via -r requirements.in
 pyephem==3.7.7.0          # via -r requirements.in
 pyflakes==2.1.1           # via -r requirements.in
 pygresql==5.1.1           # via -r requirements.in
@@ -57,7 +57,6 @@ simpleflock==0.0.3        # via -r requirements.in
 six==1.14.0               # via astroid, cycler, h5py, python-dateutil
 sqlalchemy==1.3.15        # via -r requirements.in
 tqdm==4.45.0              # via cdsapi
-typed-ast==1.4.1          # via astroid
 urllib3==1.25.8           # via requests
 werkzeug==1.0.0           # via flask
 wrapt==1.11.2             # via astroid

--- a/src/odinapi/utils/encrypt_util.py
+++ b/src/odinapi/utils/encrypt_util.py
@@ -11,14 +11,14 @@ SECRET_KEY = os.environ.get(
 
 def encrypt(msg):
     msg = msg + ' '*(16 - (len(msg) % 16 or 16))
-    cipher = AES.new(SECRET_KEY, AES.MODE_ECB)
+    cipher = AES.new(SECRET_KEY.encode(), AES.MODE_ECB)
     return base64.urlsafe_b64encode(
         cipher.encrypt(msg.encode())
     ).decode()
 
 
 def decrypt(msg):
-    cipher = AES.new(SECRET_KEY, AES.MODE_ECB)
+    cipher = AES.new(SECRET_KEY.encode(), AES.MODE_ECB)
     return cipher.decrypt(
         base64.urlsafe_b64decode(msg.encode())
     ).decode().strip()


### PR DESCRIPTION
This uses the same encryption but with pycryptodome, but there's a security issue with the actual method used:

> For symmetric key cryptography:
> 
>     Symmetric ciphers do not have ECB as default mode anymore.
>     ECB is not semantically secure and it exposes correlation across blocks.
>     An expression like AES.new(key) will now fail.
>     If ECB is the desired mode, one has to explicitly use AES.new(key, AES.MODE_ECB).
> 

Still this removes the last of those pesky warnings in #11 

I have now idea of how we go about changing the algorithm though. So far I've found it used here in `odin-api` and in `qqjobs` but I'm guessing it's in more places and then it's the whole business of rolling it out.