### PR TITLE
Fine-ite

### DIFF
--- a/src/odinapi/api.py
+++ b/src/odinapi/api.py
@@ -463,6 +463,8 @@ class ExtendedEncoder(JSONEncoder):
         if isinstance(obj, np.int_):
             return int(obj)
         if isinstance(obj, np.float_):
+            if not np.isfinite(obj):
+                return None
             return float(obj)
         return JSONEncoder.default(self, obj)
 


### PR DESCRIPTION
Ensure that floats are finite or else encode as `null`. This means there's no way to distinguish `null`/`NaN`/`Inf`/`-Inf` in the response data. It's impossible for me to know if this affects the UI or research code using the API in a negative way though, but it could be a partial fix for #44 