### PR TITLE
Only finit

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -79,8 +79,10 @@ def odinapi_service(docker_ip, docker_services, docker_compose_file):
     )
     yield url
     logs = docker_services._docker_compose.execute('logs webapi')
+    print("--- Start Docker Logs ---")
     for line in logs.decode().split('\n'):
         print(line)
+    print("--- End Docker Logs ---")
 
 
 @pytest.fixture(scope='session')

--- a/requirements.in
+++ b/requirements.in
@@ -28,4 +28,5 @@ requests
 scipy
 setuptools
 simpleflock
+simplejson
 sqlalchemy

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,6 +54,7 @@ pytz==2019.3              # via dateutils
 requests==2.23.0          # via -r requirements.in, cdsapi
 scipy==1.4.1              # via -r requirements.in
 simpleflock==0.0.3        # via -r requirements.in
+simplejson==3.17.0        # via -r requirements.in
 six==1.14.0               # via astroid, cycler, h5py, python-dateutil
 sqlalchemy==1.3.15        # via -r requirements.in
 tqdm==4.45.0              # via cdsapi

--- a/src/odinapi/api.py
+++ b/src/odinapi/api.py
@@ -1,4 +1,6 @@
 """A simple datamodel implementation"""
+import  math
+
 from flask import Flask, Blueprint
 from flask.json import JSONEncoder
 import numpy as np
@@ -466,6 +468,9 @@ class ExtendedEncoder(JSONEncoder):
             if not np.isfinite(obj):
                 return None
             return float(obj)
+        if isinstance(obj, float) and not math.isfinite(obj):
+            return None
+
         return JSONEncoder.default(self, obj)
 
 

--- a/src/odinapi/api.py
+++ b/src/odinapi/api.py
@@ -463,6 +463,8 @@ class ExtendedEncoder(JSONEncoder):
         if isinstance(obj, np.int_):
             return int(obj)
         if isinstance(obj, np.float_):
+            if not np.isfinite(obj):
+                return None
             return float(obj)
         return JSONEncoder.default(self, obj)
 

--- a/src/odinapi/api.py
+++ b/src/odinapi/api.py
@@ -1,9 +1,5 @@
 """A simple datamodel implementation"""
-import  math
-
 from flask import Flask, Blueprint
-from flask.json import JSONEncoder
-import numpy as np
 
 from odinapi.utils.swagger import SwaggerSpecView, SWAGGER
 from odinapi.views.views import (
@@ -458,20 +454,3 @@ blueprint = Blueprint(
     'swagger', __name__, static_url_path='/apidocs',
     static_folder='/swagger-ui')
 app.register_blueprint(blueprint)
-
-
-class ExtendedEncoder(JSONEncoder):
-    def default(self, obj):
-        if isinstance(obj, np.int_):
-            return int(obj)
-        if isinstance(obj, np.float_):
-            if not np.isfinite(obj):
-                return None
-            return float(obj)
-        if isinstance(obj, float) and not math.isfinite(obj):
-            return None
-
-        return JSONEncoder.default(self, obj)
-
-
-app.json_encoder = ExtendedEncoder

--- a/src/odinapi/views/level2.py
+++ b/src/odinapi/views/level2.py
@@ -701,8 +701,8 @@ class Level2ViewScan(Level2ProjectBaseView):
                 'Data': info['L2anc'], 'Type': 'L2anc',
                 'Count': len(info['L2anc'])},
         }
-        return {'Data': data, 'Type': 'mixed',
-                'Count': None}
+        mixed = {'Data': data, 'Type': 'mixed', 'Count': None}
+        return mixed
 
 
 SWAGGER.add_type('L2i', {

--- a/src/systemtest/level2_test_data.py
+++ b/src/systemtest/level2_test_data.py
@@ -2,7 +2,6 @@
 from collections import namedtuple
 from copy import deepcopy
 import json
-import math
 import os
 import re
 

--- a/src/systemtest/level2_test_data.py
+++ b/src/systemtest/level2_test_data.py
@@ -1,8 +1,10 @@
 """Provide functions for inserting level2 test data to api"""
-import os
-import json
 from collections import namedtuple
 from copy import deepcopy
+import json
+import math
+import os
+import re
 
 import requests
 
@@ -35,6 +37,17 @@ def get_write_url(data, project_name, host):
 
 def insert_test_data(project_name, host, file_name='odin_result.json'):
     data = get_test_data(file_name)
+    urlinfo = get_write_url(data, project_name, host)
+    r = requests.post(urlinfo.url, json=data)
+    return r, urlinfo
+
+
+def insert_inf_test_data(
+    project_name: str, host: str, file_name: str = 'odin_result.json',
+):
+    with open(os.path.join(TEST_DATA_DIR, file_name)) as inp:
+        text = re.sub(r'"MinLmFactor": 1,', '"MinLmFactor": NaN,', inp.read())
+    data = json.loads(text)
     urlinfo = get_write_url(data, project_name, host)
     r = requests.post(urlinfo.url, json=data)
     return r, urlinfo

--- a/src/systemtest/test_level2.py
+++ b/src/systemtest/test_level2.py
@@ -1423,10 +1423,9 @@ class TestReadLevel2:
     def test_doesnt_return_infs(
         self, odinapi_service, fake_data_with_inf,
     ):
-        scanid = fake_data_with_inf.scan_id,
+        scanid, = fake_data_with_inf.scan_id,
         freqmode = fake_data_with_inf.freq_mode
-        url = f'{odinapi_service}/rest_api/v5/level2/{PROJECT_NAME}/{freqmode}/{scanid}/'
-        print(url)
+        url = f'{odinapi_service}/rest_api/v5/level2/development/{PROJECT_NAME}/{freqmode}/{scanid}/'  # noqa
         r = requests.get(url)
         assert r.status_code == http.client.OK, r.text
         assert 'NaN' not in r.text


### PR DESCRIPTION
Attempt 2

No more jsonify on OK, instead encode with simplejson to remove nan.

Includes test to make sure this works.

If test-coverage isn't complete of the api there's a non-zero risk that various endpoints stops working if they can have data that jsonify automagically handled but we need to explicitly handle now.