### PR TITLE
fixing argparse and database connection problems

### DIFF
--- a/src/odinapi/utils/smrl2filewriter.py
+++ b/src/odinapi/utils/smrl2filewriter.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import os
+import sys
 import datetime as dt
 import argparse
 import attr
@@ -24,7 +25,7 @@ class L2Getter:
         return datamodel.to_l2i(self.db2.get_L2i(self.freqmode, scanid))
 
     def get_l2anc(self, l2: Dict[str, Any]) -> datamodel.L2anc:
-        return datamodel.to_l2anc(get_ancillary_data(self.db1, [l2])[0])
+        return datamodel.to_l2anc(get_ancillary_data(self.db1(), [l2])[0])
 
     def get_l2full(self, scanid: int) -> datamodel.L2Full:
         l2dict = self.db2.get_L2(self.freqmode, scanid, self.product)[0]
@@ -170,7 +171,7 @@ def cli(argv: List = []) -> None:
     )
     parser.add_argument(
         "freqmode",
-        type=str,
+        type=int,
         help="frequency mode",
     )
     parser.add_argument(
@@ -195,7 +196,7 @@ def cli(argv: List = []) -> None:
 
     date_start = dt.datetime.strptime(args.date_start, '%Y-%m-%d')
     date_end = dt.datetime.strptime(args.date_end, '%Y-%m-%d')
-    db1 = DatabaseConnector()
+    db1 = DatabaseConnector
     db2 = level2db.Level2DB(args.project)
     for product in args.products:
         process_period(
@@ -212,4 +213,4 @@ def cli(argv: List = []) -> None:
 
 
 if __name__ == "__main__":
-    cli()
+    cli(sys.argv[1:])

--- a/src/test/test_smrl2filewriter.py
+++ b/src/test/test_smrl2filewriter.py
@@ -266,6 +266,22 @@ class TestL2Getter:
         'odinapi.utils.smrl2filewriter.get_ancillary_data',
         return_value=[FAKE_ANC]
     )
+    def test_get_l2full_returns_none_if_no_l2data(
+        self, patched_get_ancillary_data, level2db_with_example_data
+    ):
+        l2getter = smrl2filewriter.L2Getter(
+            1,
+            "ClO / 501 GHz / 20 to 50 km",
+            FakeDatabaseConnector,
+            level2db_with_example_data
+        )
+        l2full = l2getter.get_l2full(99999999)
+        assert l2full is None
+
+    @patch(
+        'odinapi.utils.smrl2filewriter.get_ancillary_data',
+        return_value=[FAKE_ANC]
+    )
     def test_get_data_works(
         self, patched_get_ancillary_data, level2db_with_example_data
     ):
@@ -275,7 +291,7 @@ class TestL2Getter:
             FakeDatabaseConnector,
             level2db_with_example_data
         )
-        data = l2getter.get_data([7014791071, 7014791072])
+        data = l2getter.get_data([7014791071, 7014791072, 9999999999])
         assert len(data) == 1
         assert isinstance(data[0], L2Full)
         assert data[0].l2.ScanID == 7014791072


### PR DESCRIPTION
the script did not work since:

  * postgres database connection was closed by function get_ancillary_data and never reopened

  * the parsing of arguments was not done properly, freqmode should be an integer

 * it did not handle missing l2data