### PR TITLE
Include favicon in base template. resolves #48

### DIFF
--- a/src/odinapi/templates/base.html
+++ b/src/odinapi/templates/base.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="keywords" content="footer, address, phone, icons" />
     <meta name="referrer" content="no-referrer">
+    <link rel="icon" type="image/png" href="{{ url_for('static', filename='images/favicon.ico') }}">
     <title>Odin/SMR</title>
   </head>
   <body>

--- a/src/odinapi/templates/base.html
+++ b/src/odinapi/templates/base.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="keywords" content="footer, address, phone, icons" />
     <meta name="referrer" content="no-referrer">
-    <link rel="icon" type="image/png" href="{{ url_for('static', filename='images/favicon.ico') }}">
+    <link rel="icon" type="image/x-icon" href="{{ url_for('static', filename='images/favicon.ico') }}">
     <title>Odin/SMR</title>
   </head>
   <body>


### PR DESCRIPTION
Include favicon in base template. resolves #48

![odin_favicon](https://user-images.githubusercontent.com/358614/90023624-3931a400-dcb4-11ea-8c57-25c93d4345d4.png)


Other similar issues have now appeared however, see issue #55