### PR TITLE
Vds time format

### DIFF
--- a/src/odinapi/views/views.py
+++ b/src/odinapi/views/views.py
@@ -803,7 +803,7 @@ class VdsInstrumentInfo(MethodView):
         datadict = {'VDS': []}
         for row in result:
             data = dict()
-            data['Date'] = row['date']
+            data['Date'] = row['date'].isoformat()
             data['Backend'] = row['backend']
             data['FreqMode'] = row['freqmode']
             data['Species'] = row['species']


### PR DESCRIPTION
date to isoformat. without this the endpoint returns the date in this ugly format: 'Sat, 15 Sep 2012 00:00:00 GMT',
and this is not even a date so our documentation is wrong.