### PR TITLE
import solardata

### DIFF
--- a/src/scripts/getsolar.sh
+++ b/src/scripts/getsolar.sh
@@ -1,4 +1,4 @@
 #! /bin/bash -ue
 year=`date +%Y -d '-5 years'`
 curl -o /var/lib/odindata/sw.txt http://www.celestrak.com/SpaceData/sw${year}0101.txt 
-processsolar
+./processsolar.py

--- a/src/scripts/processsolar.py
+++ b/src/scripts/processsolar.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.8
+#!/usr/local/bin/python
 from fortranformat import FortranRecordReader
 import datetime as DT
 import sqlite3 as sqlite
@@ -100,3 +100,7 @@ def processsolar():
 
     db.commit()
     db.close()
+
+
+if __name__ == "__main__":
+    processsolar()


### PR DESCRIPTION
solardata was not imported into the solar database, since march 2020. this explains why we get server internal error from the ptz endpoint for data after march 2020.