### PR TITLE
level2 file batch processing

### DIFF
--- a/src/odinapi/utils/batch_smrl2filewriter.py
+++ b/src/odinapi/utils/batch_smrl2filewriter.py
@@ -1,0 +1,103 @@
+import argparse
+import attr
+import json
+import os
+import sys
+import datetime as dt
+from dateutil.relativedelta import relativedelta
+from typing import List, Optional
+
+from odinapi.utils import smrl2filewriter
+
+
+MONTHS = 3  # generate files until now - MONTHS
+
+
+@attr.s
+class ProductConf:
+    project = attr.ib(type=str)
+    product = attr.ib(type=str)
+    freqmode = attr.ib(type=int)
+    start = attr.ib(type=dt.datetime)
+    end = attr.ib(type=dt.datetime)
+    outdir = attr.ib(type=str)
+
+
+def set_end(end: Optional[str]) -> dt.datetime:
+    if end is not None:
+        return dt.datetime.strptime(end, '%Y-%m-%d')
+    now = dt.datetime.utcnow()
+    return (
+        dt.datetime(now.year, now.month, 1)
+        - relativedelta(months=MONTHS)
+        - relativedelta(days=1)
+    )
+
+
+def load_config(configfile: str) -> List[ProductConf]:
+    with open(configfile, 'r') as jsonfile:
+        data = json.load(jsonfile)
+    return [
+        ProductConf(
+            product["project"],
+            product["product"],
+            int(product["freqmode"]),
+            dt.datetime.strptime(product["start"], '%Y-%m-%d'),
+            set_end(product["end"]),
+            product["outdir"],
+        )
+        for product in data["products"]
+    ]
+
+
+def cli(argv: List = []) -> None:
+    parser = argparse.ArgumentParser(
+        description="Generates Odin/SMR level2 monthly product files.",
+        formatter_class=argparse.RawTextHelpFormatter
+    )
+    parser.add_argument(
+        "configfile",
+        type=str,
+        help=(
+            'config file in json format specifying what products to process,\n'
+            'format example:\n'
+            '{\n'
+            '    "products": [\n'
+            '        {\n'
+            '            "project": "ALL-Strat-v3.0.0",\n'
+            '            "product": "ClO / 501 GHz / 20 to 55 km",\n'
+            '            "freqmode": "1",\n'
+            '            "start": "2002-01-01",\n'
+            '            "end": null,\n'
+            '            "outdir": "ALL-Strat-v3.0.0"\n'
+            '        }\n'
+            '    ]\n'
+            '}\n'
+            'end will be set to 4 months from now if end is given as null'
+        )
+    )
+    parser.add_argument(
+        "baseoutdir",
+        type=str,
+        help=(
+            "base data directory for saving output,\n"
+            "datafiles will end up in the product specific outdir "
+            "under the baseoutdir directory"
+        )
+    )
+    args = parser.parse_args(argv)
+    products_config = load_config(args.configfile)
+    for conf in products_config:
+        smrl2filewriter.cli([
+            conf.project,
+            conf.product,
+            str(conf.freqmode),
+            conf.start.strftime("%Y-%m-%d"),
+            conf.end.strftime("%Y-%m-%d"),
+            "-q",
+            os.path.join(args.baseoutdir, conf.outdir)
+        ])
+
+
+if __name__ == "__main__":
+    cli(sys.argv[1:])

--- a/src/odinapi/utils/smrl2filewriter.py
+++ b/src/odinapi/utils/smrl2filewriter.py
@@ -131,8 +131,20 @@ class L2FileCreater:
 def get_l2data(
     l2getter: L2Getter, start: dt.datetime, end: dt.datetime
 ) -> List[datamodel.L2Full]:
-    scanids = l2getter.get_scanids(start, start + relativedelta(months=1))
-    return l2getter.get_data(scanids)
+    # add some time margins when requesting scanids for a period,
+    # a scanid has an associated time that corresponds to the
+    # start time of the scan, while the time of the l2 data,
+    # that is the one of interest here, corresponds more to the
+    # mean time of the scan, so these times can differ
+    minutes = 5
+    scanids = l2getter.get_scanids(
+        start - relativedelta(minutes=minutes),
+        end + relativedelta(minutes=minutes)
+    )
+    data = l2getter.get_data(scanids)
+    return [
+        d for d in data if d.l2.Time >= start and d.l2.Time < end
+    ]
 
 
 def process_period(
@@ -144,10 +156,17 @@ def process_period(
     start: dt.datetime,
     end: dt.datetime,
     parameters: datamodel.L2File,
-    outdir: str
+    outdir: str,
+    force: bool
 ) -> None:
     l2getter = L2Getter(freqmode, product, db1, db2)
     while start < end:
+        outfile = os.path.join(
+            outdir, datamodel.generate_filename(project, product, start)
+        )
+        if os.path.isfile(outfile) and not force:
+            start += relativedelta(months=1)
+            continue
         data = get_l2data(l2getter, start, start + relativedelta(months=1))
         if len(data) == 0:
             start += relativedelta(months=1)
@@ -197,6 +216,12 @@ def cli(argv: List = []) -> None:
         default='/tmp',
         help='data directory for saving output default is /tmp',
     )
+    parser.add_argument(
+        "-f",
+        "--force",
+        action="store_true",
+        help="flag for overwriting existing files",
+    )
     args = parser.parse_args(argv)
 
     date_start = dt.datetime.strptime(args.date_start, '%Y-%m-%d')
@@ -214,6 +239,7 @@ def cli(argv: List = []) -> None:
             date_end,
             datamodel.L2FILE.parameters,
             args.outdir,
+            args.force
         )
 
 

--- a/src/odinapi/utils/smrl2filewriter.py
+++ b/src/odinapi/utils/smrl2filewriter.py
@@ -131,15 +131,14 @@ class L2FileCreater:
 def get_l2data(
     l2getter: L2Getter, start: dt.datetime, end: dt.datetime
 ) -> List[datamodel.L2Full]:
-    # add some time margins when requesting scanids for a period,
+    # add some time margin when requesting scanids for a period,
     # a scanid has an associated time that corresponds to the
     # start time of the scan, while the time of the l2 data,
     # that is the one of interest here, corresponds more to the
     # mean time of the scan, so these times can differ
     minutes = 5
     scanids = l2getter.get_scanids(
-        start - relativedelta(minutes=minutes),
-        end + relativedelta(minutes=minutes)
+        start - relativedelta(minutes=minutes), end
     )
     data = l2getter.get_data(scanids)
     return [

--- a/src/test/fixtures/odinl2.json
+++ b/src/test/fixtures/odinl2.json
@@ -1,0 +1,116 @@
+{
+    "products": [
+        {
+            "project": "ALL-Strat-v3.0.0",
+            "product": "ClO / 501 GHz / 20 to 55 km",
+            "freqmode": "1",
+            "start": "2002-01-01",
+            "end": "2002-12-31",
+            "outdir": "ALL-Strat-v3.0.0"
+        },
+        {
+            "project": "ALL-Strat-v3.0.0",
+            "product": "N2O / 502 GHz / 15 to 50 km",
+            "freqmode": "1",
+            "start": "2002-01-01",
+            "end": null,
+            "outdir": "ALL-Strat-v3.0.0"
+        },
+        {
+            "project": "ALL-Strat-v3.0.0",
+            "product": "O3 / 501 GHz / 20 to 50 km",
+            "freqmode": "1",
+            "start": "2002-01-01",
+            "end": null,
+            "outdir": "ALL-Strat-v3.0.0"
+        },
+        {
+            "project": "ALL-Strat-v3.0.0",
+            "product": "HNO3 / 545 GHz / 20 to 50 km",
+            "freqmode": "2",
+            "start": "2002-01-01",
+            "end": null,
+            "outdir": "ALL-Strat-v3.0.0"
+        },
+        {
+            "project": "ALL-Strat-v3.0.0",
+            "product": "O3 / 545 GHz / 20 to 85 km",
+            "freqmode": "2",
+            "start": "2002-01-01",
+            "end": null,
+            "outdir": "ALL-Strat-v3.0.0"
+        },
+        {
+            "project": "ALL-Strat-v3.0.0",
+            "product": "Temperature / 545 GHz / 15 to 65 km",
+            "freqmode": "2",
+            "start": "2002-01-01",
+            "end": null,
+            "outdir": "ALL-Strat-v3.0.0"
+        },
+        {
+            "project": "ALL-Strat-v3.0.0",
+            "product": "H2O / 488 GHz / 20 to 70 km",
+            "freqmode": "8",
+            "start": "2002-01-01",
+            "end": null,
+            "outdir": "ALL-Strat-v3.0.0"
+        },
+        {
+            "project": "ALL-Strat-v3.0.0",
+            "product": "O3 / 488 GHz / 20 to 60 km",
+            "freqmode": "8",
+            "start": "2002-01-01",
+            "end": null,
+            "outdir": "ALL-Strat-v3.0.0"
+        },
+        {
+            "project": "ALL-Meso-v3.0.0",
+            "product": "H2O - 557 GHz - 45 to 100 km",
+            "freqmode": "13",
+            "start": "2002-01-01",
+            "end": null,
+            "outdir": "ALL-Meso-v3.0.0"
+        },
+        {
+            "project": "ALL-Meso-v3.0.0",
+            "product": "O3 - 557 GHz - 45 to 90 km",
+            "freqmode": "13",
+            "start": "2002-01-01",
+            "end": null,
+            "outdir": "ALL-Meso-v3.0.0"
+        },
+        {
+            "project": "ALL-Meso-v3.0.0",
+            "product": "Temperature - 557 (Fmode 13) - 45 to 90 km",
+            "freqmode": "13",
+            "start": "2002-01-01",
+            "end": null,
+            "outdir": "ALL-Meso-v3.0.0"
+        },
+        {
+            "project": "ALL19lowTunc",
+            "product": "H2O - 557 GHz - 45 to 100 km",
+            "freqmode": "19",
+            "start": "2002-01-01",
+            "end": null,
+            "outdir": "ALL19lowTunc"
+        },
+        {
+            "project": "ALL19lowTunc",
+            "product": "O3 - 557 GHz - 45 to 90 km",
+            "freqmode": "19",
+            "start": "2002-01-01",
+            "end": null,
+            "outdir": "ALL19lowTunc"
+        },
+        {
+            "project": "ALL19lowTunc",
+            "product": "Temperature - 557 (Fmode 19) - 45 to 90 km",
+            "freqmode": "19",
+            "start": "2003-01-01",
+            "end": "2004-12-31",
+            "outdir": "ALL-Meso-v3.0.0"
+        }
+    ]
+}

--- a/src/test/test_batch_smrl2filewriter.py
+++ b/src/test/test_batch_smrl2filewriter.py
@@ -1,0 +1,78 @@
+import os
+import datetime as dt
+from unittest.mock import call, patch, ANY
+
+import pytest  # type: ignore
+
+from odinapi.utils import batch_smrl2filewriter
+
+
+CONFIG_FILE = os.path.join(
+    os.path.dirname(__file__), "fixtures", "odinl2.json"
+)
+
+
+@pytest.mark.parametrize("index,expect", (
+    (
+        0,
+        batch_smrl2filewriter.ProductConf(
+            project="ALL-Strat-v3.0.0",
+            product="ClO / 501 GHz / 20 to 55 km",
+            freqmode=1,
+            start=dt.datetime(2002, 1, 1),
+            end=dt.datetime(2002, 12, 31),
+            outdir="ALL-Strat-v3.0.0",
+        ),
+    ),
+    (
+        13,
+        batch_smrl2filewriter.ProductConf(
+            project="ALL19lowTunc",
+            product="Temperature - 557 (Fmode 19) - 45 to 90 km",
+            freqmode=19,
+            start=dt.datetime(2003, 1, 1),
+            end=dt.datetime(2004, 12, 31),
+            outdir="ALL-Meso-v3.0.0",
+        ),
+    ),
+))
+def test_load_config(index, expect):
+    configs = batch_smrl2filewriter.load_config(CONFIG_FILE)
+    assert configs[index] == expect
+
+
+@pytest.mark.freeze_time('2017-05-21')
+@pytest.mark.parametrize("end,expect", (
+    (None, dt.datetime(2017, 1, 31)),
+    ("2006-01-01", dt.datetime(2006, 1, 1)),
+))
+def test_set_end(end, expect):
+    assert batch_smrl2filewriter.set_end(end) == expect
+
+
+@patch('odinapi.utils.smrl2filewriter.cli', return_value=None)
+def test_cli(patched_smrl2filewriter_cli):
+    batch_smrl2filewriter.cli(
+        [CONFIG_FILE, "savedir"]
+    )
+    patched_smrl2filewriter_cli.assert_has_calls([
+        call([
+            'ALL-Strat-v3.0.0',
+            'ClO / 501 GHz / 20 to 55 km',
+            '1',
+            '2002-01-01',
+            '2002-12-31',
+            '-q',
+            'savedir/ALL-Strat-v3.0.0'
+        ]),
+        ANY, ANY, ANY, ANY, ANY, ANY, ANY, ANY, ANY, ANY, ANY, ANY,
+        call([
+            'ALL19lowTunc',
+            'Temperature - 557 (Fmode 19) - 45 to 90 km',
+            '19',
+            '2003-01-01',
+            '2004-12-31',
+            '-q',
+            'savedir/ALL-Meso-v3.0.0'
+        ])
+    ])

--- a/src/test/test_smrl2filewriter.py
+++ b/src/test/test_smrl2filewriter.py
@@ -330,7 +330,8 @@ def test_process_period_finishes_without_failure(patched_get_l2data, level2db):
         dt.datetime(2010, 1, 1),
         dt.datetime(2010, 2, 28),
         L2FILE.parameters,
-        "/tmp"
+        "/tmp",
+        True
     )
     patched_get_l2data.assert_has_calls(
         [
@@ -353,7 +354,8 @@ def test_process_period_creates_file(patched_get_l2data, level2db, tmpdir):
         dt.datetime(2010, 1, 1),
         dt.datetime(2010, 1, 31),
         L2FILE.parameters,
-        tmpdir
+        tmpdir,
+        True
     )
     patched_get_l2data.assert_has_calls(
         [call(ANY, dt.datetime(2010, 1, 1), dt.datetime(2010, 2, 1))]
@@ -365,7 +367,7 @@ def test_process_period_creates_file(patched_get_l2data, level2db, tmpdir):
 @patch('odinapi.utils.smrl2filewriter.level2db.Level2DB', return_value=None)
 def test_cli_works(patched_level2db, patched_process_period):
     smrl2filewriter.cli([
-        "proj", "prod", "1", "2000-01-01", "2000-01-31", "-q", "/out"
+        "proj", "prod", "1", "2000-01-01", "2000-01-31", "-q", "/out", "-f"
     ])
     patched_process_period.assert_has_calls([
         call(
@@ -377,6 +379,7 @@ def test_cli_works(patched_level2db, patched_process_period):
             dt.datetime(2000, 1, 1),
             dt.datetime(2000, 1, 31),
             L2FILE.parameters,
-            "/out"
+            "/out",
+            True
         )
     ])

--- a/src/test/test_smrl2filewriter.py
+++ b/src/test/test_smrl2filewriter.py
@@ -363,6 +363,27 @@ def test_process_period_creates_file(patched_get_l2data, level2db, tmpdir):
     assert os.path.isfile(expectfile)
 
 
+@patch('odinapi.utils.smrl2filewriter.os.path.isfile', return_value=True)
+@patch('odinapi.utils.smrl2filewriter.get_l2data', return_value=l2data())
+def test_process_period_does_not_overwrite_file(
+    patched_get_l2data, patched_isfile, level2db, tmpdir
+):
+    smrl2filewriter.process_period(
+        DatabaseConnector,
+        level2db,
+        "projx",
+        0,
+        "prodx",
+        dt.datetime(2010, 1, 1),
+        dt.datetime(2010, 3, 31),
+        L2FILE.parameters,
+        tmpdir,
+        False
+    )
+    patched_isfile.assert_called()
+    patched_get_l2data.assert_not_called()
+
+
 @patch('odinapi.utils.smrl2filewriter.process_period', return_value=None)
 @patch('odinapi.utils.smrl2filewriter.level2db.Level2DB', return_value=None)
 def test_cli_works(patched_level2db, patched_process_period):

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ skipsdist = true
 [testenv]
 deps=
 	pytest
-        pytest-docker-db
+	pytest-docker-db
 	pytest-freezegun
 	-rrequirements.txt
 commands = pytest src/test --junitxml=result.xml {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,8 @@ skipsdist = true
 [testenv]
 deps=
 	pytest
-	pytest-docker-db
-        pytest-freezegun
+        pytest-docker-db
+	pytest-freezegun
 	-rrequirements.txt
 commands = pytest src/test --junitxml=result.xml {posargs}
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ skipsdist = true
 deps=
 	pytest
 	pytest-docker-db
+        pytest-freezegun
 	-rrequirements.txt
 commands = pytest src/test --junitxml=result.xml {posargs}
 


### PR DESCRIPTION
adding script that will allow for an automatic batch processing of monthly level2 files.

the intention is that we will run this script from a crontab on malachite inside a docker container.

something like this: 
docker run --rm -v ~/.odin_level2.json:/odin_level2.json:ro python odinapi/utils/batch_smrl2filewriter.py odin_level2.json /data/odin-l2-data

the odin_level2.json file specify what product files we will generate, the included test file is such an example.

Existing level2 files will not be overwritten with this processing.

Resolves #47 
