### PR TITLE
update project entry for CO

### DIFF
--- a/src/odinapi/templates/dataaccess.html
+++ b/src/odinapi/templates/dataaccess.html
@@ -455,7 +455,7 @@ For a detailed discussion of the different products, see the
                 </tr>
                 <tr>
                   <td>Carbon monoxide</td>
-                  <td><code>development/ALL</code></td>
+                  <td><code>ALL-Meso-v3.0.0</code></td>
                   <td><code>CO - 576 GHz</code></td>
                   <td>50–115 km</td>
                   <td>Sporadic temporal coverage</td>

--- a/src/systemtest/test_browser.py
+++ b/src/systemtest/test_browser.py
@@ -22,7 +22,7 @@ def chrome():
         './node_modules/chromedriver/bin/chromedriver',
         options=chrome_options
     )
-    driver.implicitly_wait(2)
+    driver.implicitly_wait(4)
     yield driver
     driver.quit()
 


### PR DESCRIPTION
I have moved CO - 576 GHz (FM14, 22, and 24) from development/ALL to ALL-Meso-v3.0.0,
and development/ALL19lowTunc to  ALL-Meso-v3.0.0 in the level2 mongo database according
to the task description

This PR is trivial. I change the project entry to  ALL-Meso-v3.0.0 for CO - 576 GHz.
It seems we have no recommendations for using FM19 data...

Resolves #82