### PR TITLE
scans endpoint

### DIFF
--- a/src/odinapi/views/level2.py
+++ b/src/odinapi/views/level2.py
@@ -493,6 +493,7 @@ class Level2ViewComments(Level2ProjectBaseView):
 SWAGGER.add_type('level2_scan_info', {
     "ScanID": int,
     "Date": str,
+    "StartTime": str,
     "URLS": {
         "URL-level2": str,
         "URL-spectra": str,
@@ -534,6 +535,8 @@ class Level2ViewScans(Level2ProjectBaseView):
         for scan in scans:
             scan['Date'] = time_util.stw2datetime(
                 scan['ScanID']).date().isoformat()
+            scan['StartTime'] = time_util.stw2datetime(
+                scan['ScanID']).time().isoformat()
             scan['URLS'] = get_scan_urls(
                 version, project, freqmode, scan['ScanID'])
         count = db.count_scans(freqmode, **param)

--- a/src/odinapi/views/level2.py
+++ b/src/odinapi/views/level2.py
@@ -493,7 +493,6 @@ class Level2ViewComments(Level2ProjectBaseView):
 SWAGGER.add_type('level2_scan_info', {
     "ScanID": int,
     "Date": str,
-    "StartTime": str,
     "URLS": {
         "URL-level2": str,
         "URL-spectra": str,
@@ -534,9 +533,7 @@ class Level2ViewScans(Level2ProjectBaseView):
             db.get_scans(freqmode, limit=limit, offset=offset, **param))
         for scan in scans:
             scan['Date'] = time_util.stw2datetime(
-                scan['ScanID']).date().isoformat()
-            scan['StartTime'] = time_util.stw2datetime(
-                scan['ScanID']).time().isoformat()
+                scan['ScanID']).isoformat()
             scan['URLS'] = get_scan_urls(
                 version, project, freqmode, scan['ScanID'])
         count = db.count_scans(freqmode, **param)

--- a/src/systemtest/test_level2.py
+++ b/src/systemtest/test_level2.py
@@ -422,6 +422,8 @@ class TestReadLevel2:
                 ])
 
             assert scan['ScanID'] == urlinfo.scan_id
+            assert scan['Date'] == '2015-01-12'
+            assert scan['StartTime'] == '00:25:03.220790'
 
     @pytest.mark.parametrize('version,comment,expected_scans', (
         (

--- a/src/systemtest/test_level2.py
+++ b/src/systemtest/test_level2.py
@@ -422,8 +422,7 @@ class TestReadLevel2:
                 ])
 
             assert scan['ScanID'] == urlinfo.scan_id
-            assert scan['Date'] == '2015-01-12'
-            assert scan['StartTime'] == '00:25:03.220790'
+            assert scan['Date'] == '2015-01-12T00:25:03.220790'
 
     @pytest.mark.parametrize('version,comment,expected_scans', (
         (


### PR DESCRIPTION
The Date parameter of the response class of the get scans endpoint:

get /rest_api/v5/level2/{project}/{freqmode}/scans/ 

now is a datetime 

The Date parameter represents the start time of the scan, and not the
mean time of the scan as e.g. the MJD parameter as returned by 
get /rest_api/v5/level2/{project}/{freqmode}/{scanno}/L2/  
endpoint.

The scans endpoint works on data fetched from the L2i database table,
and the mean time of the l2data is not available in this table.
If we change to using data from the L2 table the response time will
be much slower.

Resloves  #78