### PR TITLE
Update doi-link for SANOMA

### DIFF
--- a/src/odinapi/templates/index.html
+++ b/src/odinapi/templates/index.html
@@ -127,7 +127,7 @@
 
         <p>
           We refer the users to the article <a
-            href="https://doi.org/10.5194/acp-2018-39">"An empirical model of
+            href="https://doi.org/10.5194/acp-18-13393-2018">"An empirical model of
             nitric oxide in the upper mesosphere and lower thermosphere based
             on 12 years of Odin-SMR measurements"</a>, by J. Kiviranta, K.
           Pérot, P. Eriksson and D. Murtagh, published in Atmospheric Chemistry


### PR DESCRIPTION
Resolves #96 

I took the doi-link from the pdf, rather than linking to the pdf-directly, since that is supposed to be more persistent. I've checked that they lead to the same version.