### PR TITLE
interpolating for apriori data

### DIFF
--- a/src/odinapi/views/read_apriori.py
+++ b/src/odinapi/views/read_apriori.py
@@ -37,18 +37,15 @@ def get_datadict(data, source):
 def get_interpolation_weights(
     xs: np.array, x: float, doy_interpolation: bool = False
 ) -> Tuple[int, int, float, float]:
-    if x >= xs[-1]:
-        if doy_interpolation:
-            dx = xs[0] + (DAYS_PER_YEAR - xs[-1])
-            w1 = (min(x, DAYS_PER_YEAR) - xs[-1]) / dx
-            return 0, xs.size - 1, w1, 1. - w1
-        return 0, xs.size - 1, 0., 1.
-    if x <= xs[0]:
-        if doy_interpolation:
-            dx = xs[0] + (DAYS_PER_YEAR - xs[-1])
-            w2 = (xs[0] - x) / dx
-            return 0, xs.size - 1, 1. - w2, w2
+    if x <= xs[0] and not doy_interpolation:
         return 0, xs.size - 1, 1., 0.
+    if x >= xs[-1] and not doy_interpolation:
+        return 0, xs.size - 1, 0., 1.
+    if (x >= xs[-1] or x <= xs[0]) and doy_interpolation:
+        dx = DAYS_PER_YEAR + xs[0] - xs[xs.size - 1]
+        xi = min(x, DAYS_PER_YEAR)  # neglect leap year
+        w1 = ((xi - xs[xs.size - 1]) % DAYS_PER_YEAR) / dx
+        return 0, xs.size - 1, w1, 1. - w1
     ind2 = np.argmax(x <= xs)
     ind1 = ind2 - 1
     dx = xs[ind2] - xs[ind1]

--- a/src/test/views/test_read_apriori.py
+++ b/src/test/views/test_read_apriori.py
@@ -58,7 +58,7 @@ def test_get_interpolation_weights(doy, doy_interpolation, expect):
     doys = np.array([5, 10, 15, 350, 355, 360])
     id1, id2, w1, w2 = read_apriori.get_interpolation_weights(
         doys, doy, doy_interpolation=doy_interpolation)
-    assert (id1, id2, w1, w2) == expect
+    np.testing.assert_allclose((id1, id2, w1, w2), expect, atol=1e-6)
 
 
 def test_returns_expected_data_keys():

--- a/src/test/views/test_read_apriori.py
+++ b/src/test/views/test_read_apriori.py
@@ -36,6 +36,22 @@ def test_returns_altitude_for_mipas(co_mipas):
     assert altitudes == list(range(18000, 50000, 1000))
 
 
+@pytest.mark.parametrize("x,expect", (
+    (-90., (0, 1, 1.0, 0.0)),
+    (-80., (0, 1, 1.0, 0.0)),
+    (-60., (0, 1, 0.5, 0.5)),
+    (-40., (0, 1, 0.0, 1.0)),
+    (-20., (1, 2, 0.5, 0.5)),
+    (60., (3, 4, 0.5, 0.5)),
+    (80., (3, 4, 0.0, 1.0)),
+    (90., (3, 4, 0.0, 1.0)),
+))
+def test_get_interpolation_weights(x, expect):
+    xs = np.array([-80, -40, 0, 40, 80])
+    id1, id2, w1, w2 = read_apriori.get_interpolation_weights(xs, x)
+    assert (id1, id2, w1, w2) == expect
+
+
 def test_returns_expected_data_keys():
     species = 'CO2'
     day_of_year = 14

--- a/src/test/views/test_read_apriori.py
+++ b/src/test/views/test_read_apriori.py
@@ -41,6 +41,7 @@ def test_returns_altitude_for_mipas(co_mipas):
     (-80., (0, 1, 1.0, 0.0)),
     (-60., (0, 1, 0.5, 0.5)),
     (-40., (0, 1, 0.0, 1.0)),
+    (-30., (1, 2, 0.75, 0.25)),
     (-20., (1, 2, 0.5, 0.5)),
     (60., (3, 4, 0.5, 0.5)),
     (80., (3, 4, 0.0, 1.0)),
@@ -49,6 +50,20 @@ def test_returns_altitude_for_mipas(co_mipas):
 def test_get_interpolation_weights(x, expect):
     xs = np.array([-80, -40, 0, 40, 80])
     id1, id2, w1, w2 = read_apriori.get_interpolation_weights(xs, x)
+    assert (id1, id2, w1, w2) == expect
+
+
+@pytest.mark.parametrize("x,expect", (
+    (0, (0, 3, 0.5, 0.5)),
+    (5, (0, 3, 1.0, 0.0)),
+    (360, (0, 3, 0., 1.0)),
+    (365, (0, 3, 0.5, 0.5)),
+    (366, (0, 3, 0.5, 0.5)),
+))
+def test_get_interpolation_weights_using_doy(x, expect):
+    xs = np.array([5, 10, 355, 360])
+    id1, id2, w1, w2 = read_apriori.get_interpolation_weights(
+        xs, x, doy_interpolation=True)
     assert (id1, id2, w1, w2) == expect
 
 

--- a/src/test/views/test_read_apriori.py
+++ b/src/test/views/test_read_apriori.py
@@ -179,8 +179,8 @@ def test_returns_expected_pressure():
 def test_get_apriori_co2_vmr_does_not_vary(
     species, doy, latitude, source, expect
 ):
-    # CO is constant for a given altitude in the used apriori data.
-    # Check that returned data is constant for CO, but not constant
+    # CO2 is constant for a given altitude in the used apriori data.
+    # Check that returned data is constant for CO2, but not constant
     # for all species.
     data = read_apriori.get_apriori(
         species, doy, latitude, source=source, datadir=DATADIR,

--- a/src/test/views/test_read_apriori.py
+++ b/src/test/views/test_read_apriori.py
@@ -36,34 +36,28 @@ def test_returns_altitude_for_mipas(co_mipas):
     assert altitudes == list(range(18000, 50000, 1000))
 
 
-@pytest.mark.parametrize("x,expect", (
-    (-90., (0, 1, 1.0, 0.0)),
-    (-80., (0, 1, 1.0, 0.0)),
-    (-60., (0, 1, 0.5, 0.5)),
-    (-40., (0, 1, 0.0, 1.0)),
-    (-30., (1, 2, 0.75, 0.25)),
-    (-20., (1, 2, 0.5, 0.5)),
-    (60., (3, 4, 0.5, 0.5)),
-    (80., (3, 4, 0.0, 1.0)),
-    (90., (3, 4, 0.0, 1.0)),
+@pytest.mark.parametrize("doy,doy_interpolation,expect", (
+    (0, False, (0, 5, 1.0, 0.0)),  # all weight to id1
+    (5, False, (0, 5, 1.0, 0.0)),
+    (7.5, False, (0, 1, 0.5, 0.5)),
+    (8.0, False, (0, 1, 0.4, 0.6)),
+    (10.0, False, (0, 1, 0.0, 1.0)),
+    (12.5, False, (1, 2, 0.5, 0.5)),
+    (355, False, (3, 4, 0.0, 1.0)),
+    (360, False, (0, 5, 0.0, 1.0)),
+    (365, False, (0, 5, 0.0, 1.0)),  # all weight to id2
+    (0, True, (0, 5, 0.5, 0.5)),  # equal weights to id1 and id2
+    (3, True, (0, 5, 0.8, 0.2)),
+    (5, True, (0, 5, 1.0, 0.0)),
+    (360, True, (0, 5, 0.0, 1.0)),
+    (362, True, (0, 5, 0.2, 0.8)),
+    (365, True, (0, 5, 0.5, 0.5)),  # equal weights to id1 and id2
+    (366, True, (0, 5, 0.5, 0.5)),  # doy 366 gives same result as doy 365
 ))
-def test_get_interpolation_weights(x, expect):
-    xs = np.array([-80, -40, 0, 40, 80])
-    id1, id2, w1, w2 = read_apriori.get_interpolation_weights(xs, x)
-    assert (id1, id2, w1, w2) == expect
-
-
-@pytest.mark.parametrize("x,expect", (
-    (0, (0, 3, 0.5, 0.5)),
-    (5, (0, 3, 1.0, 0.0)),
-    (360, (0, 3, 0., 1.0)),
-    (365, (0, 3, 0.5, 0.5)),
-    (366, (0, 3, 0.5, 0.5)),
-))
-def test_get_interpolation_weights_using_doy(x, expect):
-    xs = np.array([5, 10, 355, 360])
+def test_get_interpolation_weights(doy, doy_interpolation, expect):
+    doys = np.array([5, 10, 15, 350, 355, 360])
     id1, id2, w1, w2 = read_apriori.get_interpolation_weights(
-        xs, x, doy_interpolation=True)
+        doys, doy, doy_interpolation=doy_interpolation)
     assert (id1, id2, w1, w2) == expect
 
 
@@ -106,6 +100,31 @@ def test_returns_expected_pressure():
         100000., 93057.204093, 86596.432336, 80584.218776, 74989.420933,
         69783.058486, 64938.163158, 60429.639024, 56234.132519, 52329.911468,
     ])
+
+
+@pytest.mark.parametrize("species,doy,latitude,source,expect", (
+    ('CO2', 1., -90., None, 0.0003626),
+    ('CO2', 1., 35., None, 0.0003626),
+    ('CO2', 15., 35., None, 0.0003626),
+    ('CO2', 180., 35., None, 0.0003626),
+    ('CO2', 350., 35., None, 0.0003626),
+    ('CO2', 365., 35., None, 0.0003626),
+    ('CO2', 365., 80., None, 0.0003626),
+    ('CO2', 365., 90., None, 0.0003626),
+    ('CO', 1., 80., 'mipas', 0.34654013),
+    ('CO', 10., 80., 'mipas', 0.3749516),
+    ('CO', 30., 80., 'mipas', 0.2280777),
+    ('CO', 335., 80., 'mipas', 0.1782076),
+    ('CO', 355., 80., 'mipas', 0.3118149),
+    ('CO', 365., 80., 'mipas', 0.3433833),
+))
+def test_get_apriori_co2_vmr_does_not_vary(
+    species, doy, latitude, source, expect
+):
+    data = read_apriori.get_apriori(
+        species, doy, latitude, source=source, datadir=DATADIR,
+    )
+    assert data['vmr'][20] == pytest.approx(expect, abs=1e-7)
 
 
 def test_returns_expected_vmr():

--- a/src/test/views/test_read_apriori.py
+++ b/src/test/views/test_read_apriori.py
@@ -36,29 +36,87 @@ def test_returns_altitude_for_mipas(co_mipas):
     assert altitudes == list(range(18000, 50000, 1000))
 
 
-@pytest.mark.parametrize("doy,doy_interpolation,expect", (
-    (0, False, (0, 5, 1.0, 0.0)),  # all weight to id1
-    (5, False, (0, 5, 1.0, 0.0)),
-    (7.5, False, (0, 1, 0.5, 0.5)),
-    (8.0, False, (0, 1, 0.4, 0.6)),
-    (10.0, False, (0, 1, 0.0, 1.0)),
-    (12.5, False, (1, 2, 0.5, 0.5)),
-    (355, False, (3, 4, 0.0, 1.0)),
-    (360, False, (0, 5, 0.0, 1.0)),
-    (365, False, (0, 5, 0.0, 1.0)),  # all weight to id2
-    (0, True, (0, 5, 0.5, 0.5)),  # equal weights to id1 and id2
-    (3, True, (0, 5, 0.8, 0.2)),
-    (5, True, (0, 5, 1.0, 0.0)),
-    (360, True, (0, 5, 0.0, 1.0)),
-    (362, True, (0, 5, 0.2, 0.8)),
-    (365, True, (0, 5, 0.5, 0.5)),  # equal weights to id1 and id2
-    (366, True, (0, 5, 0.5, 0.5)),  # doy 366 gives same result as doy 365
+@pytest.mark.parametrize("x,expect", (
+    (-79, (0, 1, 0.95, 0.05)),
+    (-70, (0, 1, 0.5, 0.5)),
+    (-68, (0, 1, 0.4, 0.6)),
+    (-60, (0, 1, 0.0, 1.0)),
+    (-50, (1, 2, 0.5, 0.5)),
+    (60, (3, 4, 0.0, 1.0)),
+    (79, (4, 5, 0.05, 0.95)),
 ))
-def test_get_interpolation_weights(doy, doy_interpolation, expect):
-    doys = np.array([5, 10, 15, 350, 355, 360])
+def test_get_interpolation_weights(x, expect):
+    xs = np.array([-80, -60, -40, 40, 60, 80])
     id1, id2, w1, w2 = read_apriori.get_interpolation_weights(
-        doys, doy, doy_interpolation=doy_interpolation)
+        xs, x)
     np.testing.assert_allclose((id1, id2, w1, w2), expect, atol=1e-6)
+
+
+@pytest.mark.parametrize("doy,expect", (
+    (0, (0, 5, 0.5, 0.5)),  # equal weights to id1 and id2
+    (3, (0, 5, 0.8, 0.2)),
+    (5, (0, 5, 1.0, 0.0)),
+    (360, (0, 5, 0.0, 1.0)),
+    (362, (0, 5, 0.2, 0.8)),
+    (365, (0, 5, 0.5, 0.5)),  # equal weights to id1 and id2
+    (366, (0, 5, 0.5, 0.5)),  # doy 366 gives same result as doy 365
+))
+def test_get_interpolation_weights_for_doy(doy, expect):
+    doys = np.array([5, 10, 15, 350, 355, 360])
+    id1, id2, w1, w2 = read_apriori.get_interpolation_weights_for_doy(
+        doys, doy)
+    np.testing.assert_allclose((id1, id2, w1, w2), expect, atol=1e-6)
+
+
+@pytest.mark.parametrize("lat,expect", (
+    (-90, (0, 5, 1.0, 0.0)),  # all weight to id1
+    (-80, (0, 5, 1.0, 0.0)),
+    (-70, (0, 1, 0.5, 0.5)),
+    (-68, (0, 1, 0.4, 0.6)),
+    (-60, (0, 1, 0.0, 1.0)),
+    (-50, (1, 2, 0.5, 0.5)),
+    (60, (3, 4, 0.0, 1.0)),
+    (80, (0, 5, 0.0, 1.0)),
+    (90, (0, 5, 0.0, 1.0)),  # all weight to id
+))
+def test_get_interpolation_weights_for_lat(lat, expect):
+    lats = np.array([-80, -60, -40, 40, 60, 80])
+    id1, id2, w1, w2 = read_apriori.get_interpolation_weights_for_lat(
+        lats, lat)
+    np.testing.assert_allclose((id1, id2, w1, w2), expect, atol=1e-6)
+
+
+@pytest.mark.parametrize("lat,expect", (
+    (-85, 1),
+    (-80, 1),
+    (-40, 1.5),
+    (80, 3),
+))
+def test_get_vmr_interpolated_for_lat(lat, expect):
+    vmrs = np.zeros((1, 3))
+    vmrs[0, 0] = 1.
+    vmrs[0, 1] = 2.
+    vmrs[0, 2] = 3.
+    lats = np.array([-80, 0, 80])
+    vmr = read_apriori.get_vmr_interpolated_for_lat(
+        vmrs, lats, lat)
+    assert vmr == expect
+
+
+@pytest.mark.parametrize("doy,expect", (
+    (1, 2.5),
+    (15, 1),
+    (30, 1.5),
+))
+def test_get_vmr_interpolated_for_doy(doy, expect):
+    vmrs = np.zeros((1, 1, 1, 3))
+    vmrs[0, 0, 0, 0] = 1.
+    vmrs[0, 0, 0, 1] = 2.
+    vmrs[0, 0, 0, 2] = 4.
+    doys = np.array([15, 45, 352])
+    vmr = read_apriori.get_vmr_interpolated_for_doy(
+        vmrs, doys, doy)
+    assert vmr.item() == expect
 
 
 def test_returns_expected_data_keys():
@@ -121,6 +179,9 @@ def test_returns_expected_pressure():
 def test_get_apriori_co2_vmr_does_not_vary(
     species, doy, latitude, source, expect
 ):
+    # CO is constant for a given altitude in the used apriori data.
+    # Check that returned data is constant for CO, but not constant
+    # for all species.
     data = read_apriori.get_apriori(
         species, doy, latitude, source=source, datadir=DATADIR,
     )
@@ -139,20 +200,6 @@ def test_returns_expected_vmr():
         [0.000365] * 16 + [0.000364, 0.000364, 0.000363, 0.000363],
         atol=0.0000005,
     )
-
-
-@pytest.mark.parametrize('lat,expect', (
-    (90, 85),
-    (-90, -85),
-    (3, 3),
-))
-def test_clip_lats_outside_range(lat, expect):
-    species = 'CO2'
-    day_of_year = 14
-    data = read_apriori.get_apriori(
-        species, day_of_year, lat, datadir=DATADIR,
-    )
-    assert data['latitude'] == expect
 
 
 def test_using_alternative_source():


### PR DESCRIPTION
Corrected interpolation of apriori data. Added functiosn that returns weights for interpolation.
Should be much simpler to understand the code now. 

The doy_interpolation function allows for an interpolation between the
the two edge points of the apriori data, such that for e.g.  doy=365 the returned value
will be the average of the apriori "edges" if the doy edges of the apriori is 15 and 350.   
The year is treated to have 365 days and we neglect leap year
(doy 365 and 366 will return the same values).

I will also figure out what should be reprocessed due to the bug and make new tasks around it. 

Resolves #94 