### PR TITLE
Switch main for master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
           images: odinsmr/odin_api
           tags: |
               type=ref,event=branch
-              type=raw,value=pr
+              type=ref,event=pr
       -
         name: Build and push
         uses: docker/build-push-action@v2


### PR DESCRIPTION
The main branch is called master in Odin-API...

Also add checkout stage dealing with submodules.

The current tag configuration for the pushed dockerimage in the build file work like this:
  
  - for a PR: e.g. pr-129 (this PR)
  - for master: master (or latest) not 100 % sure until we merge

