### PR TITLE
pushing and tag PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,11 +29,30 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
-        name: Build and push
+        name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: odinsmr/odin_api
+          tags: |
+              type=ref,event=branch
+              type=ref,event=pr
+      -
+        name: Build and push pull request
         uses: docker/build-push-action@v2
+        if: ${{ github.event_name == 'pull_request' }}
         with:
           context: .
           file: ./Dockerfile
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      -
+        name: Build and push master             
+        uses: docker/build-push-action@v2
+        if: ${{ github.event_name != 'pull_request' }}
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true                                      
           tags: odinsmr/odin_api:latest
-


### PR DESCRIPTION
also trying to tag and push PRs images to dockerub.
The problem if we are not doing this is that image with tag latest
get overwritten each time on dockerhub so we can not easily rollback if the
current latest is not working. 

I have verified that after building this PR 
pr-131 is available on https://hub.docker.com/repository/docker/odinsmr/odin_api
and the image with latest tag is not updated as expected.
